### PR TITLE
fix: allow string as body

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,8 @@ const requestToFetchOptions: RequestToFetchOptions =
       } else {
         if (typeof reqOpts.body !== 'string') {
           options.body = JSON.stringify(reqOpts.body);
+        } else {
+          options.body = reqOpts.body;
         }
       }
 


### PR DESCRIPTION
It seems like `request` allows body to be a string, so cover that case here.

I believe this can circumvent a code change that would otherwise be needed as part of https://github.com/googleapis/cloud-trace-nodejs/pull/858.