### PR TITLE
fix: support uri and url options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as r from 'request';  // Only for type declarations
 import fetch, * as f from 'node-fetch';
 import {PassThrough} from 'stream';
@@ -9,7 +7,7 @@ import * as uuid from 'uuid';
 const HttpsProxyAgent = require('https-proxy-agent');
 
 interface RequestToFetchOptions {
-  (reqOpts: r.OptionsWithUri): [string, f.RequestInit];
+  (reqOpts: r.Options): [string, f.RequestInit];
 }
 
 interface Headers {
@@ -20,48 +18,48 @@ interface FetchToRequestResponse {
   (res: f.Response): r.Response;
 }
 
-const requestToFetchOptions: RequestToFetchOptions =
-    (reqOpts: r.OptionsWithUri) => {
-      const options: f.RequestInit = {
-        method: reqOpts.method || 'GET',
-        ...reqOpts.timeout && {timeout: reqOpts.timeout},
-        ...reqOpts.gzip && {compress: reqOpts.gzip},
+const requestToFetchOptions: RequestToFetchOptions = (reqOpts: r.Options) => {
+  const options: f.RequestInit = {
+    method: reqOpts.method || 'GET',
+    ...reqOpts.timeout && {timeout: reqOpts.timeout},
+    ...reqOpts.gzip && {compress: reqOpts.gzip},
 
-      };
+  };
 
-      if (typeof reqOpts.json === 'object') {
-        // Add Content-type: application/json header
-        if (!reqOpts.headers) {
-          reqOpts.headers = {};
-        }
-        reqOpts.headers['Content-Type'] = 'application/json';
+  if (typeof reqOpts.json === 'object') {
+    // Add Content-type: application/json header
+    if (!reqOpts.headers) {
+      reqOpts.headers = {};
+    }
+    reqOpts.headers['Content-Type'] = 'application/json';
 
-        // Set body to JSON representation of value
-        options.body = JSON.stringify(reqOpts.json);
-      } else {
-        if (typeof reqOpts.body !== 'string') {
-          options.body = JSON.stringify(reqOpts.body);
-        } else {
-          options.body = reqOpts.body;
-        }
-      }
+    // Set body to JSON representation of value
+    options.body = JSON.stringify(reqOpts.json);
+  } else {
+    if (typeof reqOpts.body !== 'string') {
+      options.body = JSON.stringify(reqOpts.body);
+    } else {
+      options.body = reqOpts.body;
+    }
+  }
 
-      options.headers = reqOpts.headers as Headers;
+  options.headers = reqOpts.headers as Headers;
 
-      let uri: string = reqOpts.uri as string;
-      if (reqOpts.useQuerystring === true || typeof reqOpts.qs === 'object') {
-        const qs = require('querystring');
-        const params = qs.stringify(reqOpts.qs);
-        uri = uri + '?' + params;
-      }
+  let uri = ((reqOpts as r.OptionsWithUri).uri ||
+             (reqOpts as r.OptionsWithUrl).url) as string;
+  if (reqOpts.useQuerystring === true || typeof reqOpts.qs === 'object') {
+    const qs = require('querystring');
+    const params = qs.stringify(reqOpts.qs);
+    uri = uri + '?' + params;
+  }
 
-      if (reqOpts.proxy || process.env.HTTP_PROXY || process.env.HTTPS_PROXY) {
-        const proxy = (process.env.HTTP_PROXY || process.env.HTTPS_PROXY)!;
-        options.agent = new HttpsProxyAgent(proxy);
-      }
+  if (reqOpts.proxy || process.env.HTTP_PROXY || process.env.HTTPS_PROXY) {
+    const proxy = (process.env.HTTP_PROXY || process.env.HTTPS_PROXY)!;
+    options.agent = new HttpsProxyAgent(proxy);
+  }
 
-      return [uri, options];
-    };
+  return [uri, options];
+};
 
 interface Callback {
   (err: Error|null, response?: r.Response, body?: {}|string): void;
@@ -78,10 +76,10 @@ const fetchToRequestResponse: FetchToRequestResponse = (res: f.Response) => {
 // Mimics `request`. Can be used as `request(options, callback)`
 // or `request.defaults(opts)(options, callback)`
 interface TeenyRequest {
-  (reqOpts: r.OptionsWithUri, callback: Callback): void;
+  (reqOpts: r.Options, callback: Callback): void;
   defaults:
-      ((options: r.OptionsWithUri) =>
-           ((reqOpts: r.OptionsWithUri, callback: Callback) => void));
+      ((options:
+            r.Options) => ((reqOpts: r.Options, callback: Callback) => void));
 }
 
 // create POST body from two parts as multipart/related content-type
@@ -110,7 +108,7 @@ const createMultipartStream =
     };
 
 const teenyRequest =
-    ((reqOpts: r.OptionsWithUri, callback?: Callback) => {
+    ((reqOpts: r.Options, callback?: Callback) => {
       const [uri, options] = requestToFetchOptions(reqOpts);
 
       const multipart: r.RequestPart[] = reqOpts.multipart as r.RequestPart[];
@@ -242,8 +240,8 @@ const teenyRequest =
       return;
     }) as TeenyRequest;
 
-teenyRequest.defaults = (defaults: r.OptionsWithUri) => {
-  return (reqOpts: r.OptionsWithUri,
+teenyRequest.defaults = (defaults: r.Options) => {
+  return (reqOpts: r.Options,
           callback:
               (err: Error|null, response?: r.Response, body?: {}|string) =>
                   void) => {

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,6 +1,3 @@
-
-'use strict';
-
 import * as assert from 'assert';
 import * as r from 'request';
 
@@ -19,8 +16,7 @@ describe('teeny', () => {
           done();
         });
   }), it('should set defaults', (done) => {
-    const defaultRequest =
-        teenyRequest.defaults({timeout: 60000} as r.OptionsWithUri);
+    const defaultRequest = teenyRequest.defaults({timeout: 60000} as r.Options);
     defaultRequest(
         {uri: 'https://jsonplaceholder.typicode.com/todos/1'},
         // tslint:disable-next-line:no-any


### PR DESCRIPTION
`request` supports both `uri` and `url` properties in the options object.  This adds support for both!