### PR TITLE
fix: use RequestCallback interface from Request

### DIFF
--- a/test/index.ts
+++ b/test/index.ts
@@ -1,30 +1,27 @@
 import * as assert from 'assert';
 import * as r from 'request';
-
 import {teenyRequest} from '../src';
 
 describe('teeny', () => {
   it('should get JSON', (done) => {
     teenyRequest(
         {uri: 'https://jsonplaceholder.typicode.com/todos/1'},
-        // tslint:disable-next-line:no-any
-        (error: Error|null, response?: r.Response, body?: any) => {
+        (error, response, body) => {
           assert.ifError(error);
           assert.strictEqual(response!.statusCode, 200);
           assert.notEqual(body!.userId, null);
-
           done();
         });
-  }), it('should set defaults', (done) => {
+  });
+
+  it('should set defaults', (done) => {
     const defaultRequest = teenyRequest.defaults({timeout: 60000} as r.Options);
     defaultRequest(
         {uri: 'https://jsonplaceholder.typicode.com/todos/1'},
-        // tslint:disable-next-line:no-any
-        (error: Error|null, response?: r.Response, body?: any) => {
+        (error, response, body) => {
           assert.ifError(error);
           assert.strictEqual(response!.statusCode, 200);
           assert.notEqual(body!.userId, null);
-
           done();
         });
   });


### PR DESCRIPTION
This change uses the `RequestCallback` interface already available from `Request` instead of creating a new interface.  Along with this change, we're now also passing more complete parameters in failure callbacks, similar to how `Request` behaves. This gets us closer to compatibility.