### PR TITLE
feat: include TypeScript types with release

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@types/mocha": "^5.2.5",
     "@types/nock": "^9.3.0",
     "@types/node-fetch": "^2.1.2",
-    "@types/request": "^2.47.1",
     "@types/uuid": "^3.4.4",
     "codecov": "^3.1.0",
     "gts": "^0.9.0",

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,6 +1,5 @@
 import * as assert from 'assert';
 import * as nock from 'nock';
-import * as request from 'request';
 import {Readable} from 'stream';
 
 import {teenyRequest} from '../src';
@@ -18,7 +17,7 @@ describe('teeny', () => {
     teenyRequest({uri}, (error, response, body) => {
       assert.ifError(error);
       assert.strictEqual(response.statusCode, 200);
-      assert.ok(body.hello);
+      assert.ok(body!.hello);
       scope.done();
       done();
     });
@@ -80,7 +79,7 @@ describe('teeny', () => {
         200, '🚨', {'content-type': 'application/json'});
     teenyRequest({uri}, err => {
       assert.ok(err);
-      assert.ok(err.message.match(/^invalid json response body/));
+      assert.ok(err!.message.match(/^invalid json response body/));
       scope.done();
       done();
     });
@@ -96,10 +95,5 @@ describe('teeny', () => {
       scope.done();
       done();
     });
-  });
-
-  it('should be castable to `Request`', () => {
-    const r = teenyRequest as typeof request;
-    assert.ok(r);
   });
 });


### PR DESCRIPTION
**BREAKING CHANGE**: This commit switches many of the TypeScript interfaces from the types defined in `@types/request`, and replaces them with custom types included in the package.  This is only a breaking change at compile time for TypeScript users.

We currently rely on `@types/request`.  This causes a few issues:
- It gives users the impression we may include fields or properties we don't currently support
- We don't ship the types, so users just see `any`
- It requires pulling in `@types/request` for downstream users

I'd like to kinda drop all this by just shipping our own interfaces :)