### PR TITLE
fix!: don't parse response errors in stream mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -173,20 +173,6 @@ function teenyRequest(
     fetch(uri, options)
         .then(
             res => {
-              if (!res.ok) {
-                res.text().then(
-                    text => {
-                      const error = new RequestError(text);
-                      error.code = res.status;
-                      requestStream.emit('error', error);
-                      return;
-                    },
-                    error => {
-                      requestStream.emit('error', error);
-                    });
-                return;
-              }
-
               res.body.on('error', err => {
                 console.log('whoa there was an error, passing it on: ' + err);
                 requestStream.emit('error', err);


### PR DESCRIPTION
BREAKING CHANGE: Previously, error messages were parsed from the response body in streaming mode, and emitted to the user. This did not match callback behavior or the `request` module's behavior. Errors will now have to be parsed from the response body.

fixes #39